### PR TITLE
add password for TrustStoreConfig

### DIFF
--- a/ssl-config-core/src/main/resources/reference.conf
+++ b/ssl-config-core/src/main/resources/reference.conf
@@ -70,6 +70,7 @@ ssl-config {
       data = null
 
       # The password for loading the keystore. If null, uses no password.
+      # It's recommended to load password using environment variable
       password = null
     }
   }
@@ -91,6 +92,10 @@ ssl-config {
 
       # The data for the keystore. Either this must be non null, or path must be non null.
       data = null
+
+      # The password for loading the truststore. If null, uses no password.
+      # It's recommended to load password using environment variable
+      password = null
     }
 
   }

--- a/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/SSLContextBuilder.scala
+++ b/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/SSLContextBuilder.scala
@@ -161,7 +161,8 @@ class ConfigSSLContextBuilder(mkLogger: LoggerFactory,
 
   def trustStoreBuilder(tsc: TrustStoreConfig): KeyStoreBuilder = {
     tsc.filePath.map { f =>
-      fileBuilder(tsc.storeType, f, None)
+      val password = tsc.password.map(_.toCharArray)
+      fileBuilder(tsc.storeType, f, password)
     }.getOrElse {
       val data = tsc.data.getOrElse(throw new IllegalStateException("No truststore builder found!"))
       stringBuilder(data)

--- a/ssl-config-core/src/test/scala/com/typesafe/sslconfig/ssl/CompositeX509KeyManagerSpec.scala
+++ b/ssl-config-core/src/test/scala/com/typesafe/sslconfig/ssl/CompositeX509KeyManagerSpec.scala
@@ -48,8 +48,8 @@ object CompositeX509KeyManagerSpec extends Specification with Mockito {
         val issuers = Array[Principal]()
         val engine = mock[SSLEngine]
 
-        val serverAlias = keyManager.chooseEngineClientAlias(keyType = keyType, issuers = issuers, engine = engine)
-        serverAlias must beNull
+        val clientAlias = keyManager.chooseEngineClientAlias(keyType = keyType, issuers = issuers, engine = engine)
+        clientAlias must beNull
       }
 
       "return a result" in {
@@ -59,8 +59,18 @@ object CompositeX509KeyManagerSpec extends Specification with Mockito {
         val issuers = Array[Principal]()
         val engine = mock[SSLEngine]
 
-        val serverAlias = keyManager.chooseEngineClientAlias(keyType = keyType, issuers = issuers, engine = engine)
-        serverAlias must be_==("clientAlias")
+        val clientAlias = keyManager.chooseEngineClientAlias(keyType = keyType, issuers = issuers, engine = engine)
+        clientAlias must be_==("clientAlias")
+      }
+
+      "deal with issuers = null" in {
+        val mockKeyManager = mockExtendedX509KeyManager(serverResponse = "clientAlias")
+        val keyManager = new CompositeX509KeyManager(mkLogger, Seq(mockKeyManager))
+        val keyType = "derp"
+        val engine = mock[SSLEngine]
+
+        val clientAlias = keyManager.chooseEngineServerAlias(keyType = keyType, issuers = null, engine = engine)
+        clientAlias must be_==("clientAlias")
       }
 
       "return null" in {
@@ -70,8 +80,8 @@ object CompositeX509KeyManagerSpec extends Specification with Mockito {
         val issuers = Array[Principal]()
         val engine = mock[SSLEngine]
 
-        val serverAlias = keyManager.chooseEngineClientAlias(keyType = keyType, issuers = issuers, engine = engine)
-        serverAlias must beNull
+        val clientAlias = keyManager.chooseEngineClientAlias(keyType = keyType, issuers = issuers, engine = engine)
+        clientAlias must beNull
       }
     }
 
@@ -96,6 +106,16 @@ object CompositeX509KeyManagerSpec extends Specification with Mockito {
         val engine = mock[SSLEngine]
 
         val serverAlias = keyManager.chooseEngineServerAlias(keyType = keyType, issuers = issuers, engine = engine)
+        serverAlias must be_==("serverAlias")
+      }
+
+      "deal with issuers = null" in {
+        val mockKeyManager = mockExtendedX509KeyManager(serverResponse = "serverAlias")
+        val keyManager = new CompositeX509KeyManager(mkLogger, Seq(mockKeyManager))
+        val keyType = "derp"
+        val engine = mock[SSLEngine]
+
+        val serverAlias = keyManager.chooseEngineServerAlias(keyType = keyType, issuers = null, engine = engine)
         serverAlias must be_==("serverAlias")
       }
 

--- a/ssl-config-core/src/test/scala/com/typesafe/sslconfig/ssl/SSLConfigParserSpec.scala
+++ b/ssl-config-core/src/test/scala/com/typesafe/sslconfig/ssl/SSLConfigParserSpec.scala
@@ -146,12 +146,12 @@ object SSLConfigParserSpec extends Specification {
       actual.debug.ssl must beTrue
     }
 
-    "parse ssl-config.trustBuilder section" in {
+    "parse ssl-config.trustManager section" in {
       val info = parseThis("""
                               |trustManager = {
                               |  algorithm = "trustme"
                               |  stores = [
-                              |    { type: "storeType", path: "trusted" }
+                              |    { type: "storeType", path: "trusted", password: "changeit" }
                               |  ]
                               |}
                             """.stripMargin)
@@ -161,6 +161,7 @@ object SSLConfigParserSpec extends Specification {
       val tsi = tmc.trustStoreConfigs(0)
       tsi.filePath must beSome.which(_ must beEqualTo("trusted"))
       tsi.storeType must_== "storeType"
+      tsi.password must beSome.which(_ must beEqualTo("changeit"))
     }
 
     "parse ssl-config.keyManager section" in {


### PR DESCRIPTION
Related to https://github.com/akka/akka/issues/20381

It's the minimal set of changes to make https://github.com/akka/akka/issues/20381 work. There are at least two more things that may be done:
1. Adding support for `DKS` keystores (https://docs.oracle.com/javase/8/docs/api/java/security/DomainLoadStoreParameter.html). I have mixed feelings about it because it seems to me that DKS config do more or less the same thing as ssl-config itself.
2. Adding support for server side SNI - changes in `CompositeX509KeyManager` would be needed (probably we should create a separate ticket for this)

It also eliminates critical bug in `CompositeX509KeyManager` which method `chooseEngineClientAlias` was throwing NPE for `issuers == null`

Also I have some codewise questions - will add them as PR comments in a moment.
