### PR TITLE
Updating readme links and repo urls from typesafehub to lightbend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 SSL Config
 ==========
 
-<a href="https://travis-ci.org/typesafehub/ssl-config"><img src="https://travis-ci.org/typesafehub/ssl-config.svg"/></a>
+<a href="https://travis-ci.org/lightbend/ssl-config"><img src="https://travis-ci.org/lightbend/ssl-config.svg"/></a>
 
 Goal and purpose of this library is to make Play's WS library as well as Akka HTTP "secure by default".
 Sadly, while Java's security has been steadily improving some settings are still left up to the user,
@@ -17,8 +17,8 @@ Versions
 
 The project is maintained on two branches:
 
-- [`master`](https://github.com/typesafehub/ssl-config/tree/master) which requires Java 8 and is used by Akka `2.4.x`.
-- [`release-0.1`](https://github.com/typesafehub/ssl-config/tree/release-0.1) which is Java 6 compatible 
+- [`master`](https://github.com/lightbend/ssl-config/tree/master) which requires Java 8 and is used by Akka `2.4.x`.
+- [`release-0.1`](https://github.com/lightbend/ssl-config/tree/release-0.1) which is Java 6 compatible 
   (does lots of manual improvements and checks that JDK6 didn't).
   Currently only the *legacy version* of Akka Streams & Http (which is `2.0.x`) uses this version. 
 
@@ -48,7 +48,7 @@ We aim to stabilise the APIs and provide a stable release eventually.
 Documentation
 =============
 
-Docs are available on: http://typesafehub.github.io/ssl-config
+Docs are available on: https://lightbend.github.io/ssl-config
 
 Recommended reading
 ===================

--- a/documentation/src/paradox/LooseSSL.md
+++ b/documentation/src/paradox/LooseSSL.md
@@ -88,7 +88,7 @@ together with `ConfigFactory.parseString`, and ensure it is never used
 outside that context.
 
 **Environment Scoping**: You can define [environment variables in
-HOCON](https://github.com/typesafehub/config/blob/master/HOCON.md#substitution-fallback-to-environment-variables)
+HOCON](https://github.com/lightbend/config/blob/master/HOCON.md#substitution-fallback-to-environment-variables)
 to ensure that any loose options are not hardcoded in configuration
 files, and therefore cannot escape an development environment.
 

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -19,8 +19,8 @@ object Common extends AutoPlugin {
 
   // sonatype
   object sonatype extends PublishToSonatype {
-     def projectUrl    = "https://github.com/typesafehub/ssl-config"
-     def scmUrl        = "git://github.com/typesafehub/ssl-config.git"
+     def projectUrl    = "https://github.com/lightbend/ssl-config"
+     def scmUrl        = "git://github.com/lightbend/ssl-config.git"
      def developers    = List(
        Developer("wsargent", "Will Sargent", "https://tersesystems.com"),
        Developer("ktoso", "Konrad Malawski", "https://project13.pl"))


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

N/A

## Purpose

Fixes the documentation links in README.md and other stale references to point to lightbend instead of typesafehub.

## Background Context

I wanted to check some of the docs linked from akka-http's [ssl-config documentaion](https://doc.akka.io/docs/akka-http/current/scala/http/server-side/server-https-support.html#ssl-config) and noticed that the link was broken. After visiting this repo, I also noticed that the docs link was broken in the README.md

## References

N/A