### PR TITLE
KeyStoreBuilder that reads key stores from class path

### DIFF
--- a/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/Config.scala
+++ b/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/Config.scala
@@ -39,7 +39,7 @@ final class KeyStoreConfig private[sslconfig](
   def withData(data: Option[String]): KeyStoreConfig = copy(data = data, filePath = None)
   /** Disables `data` – only one of those can be used at any given time. */
   def withFilePath(filePath: Option[String]): KeyStoreConfig = copy(filePath = filePath, data = None)
-  def withOnClassPath(onClassPath: Boolean): KeyStoreConfig = copy(isFileOnClasspath = onClassPath, data = None)
+  def withFileOnClassPath(isFileOnClasspath: Boolean): KeyStoreConfig = copy(isFileOnClasspath = isFileOnClasspath, data = None)
   def withPassword(value: Option[String]): KeyStoreConfig = copy(password = value)
   def withStoreType(value: String): KeyStoreConfig = copy(storeType = value)
 
@@ -116,7 +116,7 @@ final class TrustStoreConfig private[sslconfig](
   def withData(data: Option[String]): TrustStoreConfig = copy(data = data, filePath = None)
   /** Disables `data` – only one of those can be used at any given time. */
   def withFilePath(filePath: Option[String]): TrustStoreConfig = copy(filePath = filePath, data = None)
-  def withIsFileOnClasspath(isFileOnClasspath: Boolean): TrustStoreConfig = copy(isFileOnClasspath = isFileOnClasspath, data = None)
+  def withFileOnClasspath(isFileOnClasspath: Boolean): TrustStoreConfig = copy(isFileOnClasspath = isFileOnClasspath, data = None)
   def withStoreType(value: String): TrustStoreConfig = copy(storeType = value)
 
   private def copy(

--- a/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/Config.scala
+++ b/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/Config.scala
@@ -30,6 +30,7 @@ import scala.language.existentials
 final class KeyStoreConfig private[sslconfig](
   val data: Option[String],
   val filePath: Option[String],
+  val isFileOnClasspath: Boolean = false,
   val password: Option[String] = None,
   val storeType: String = KeyStore.getDefaultType) {
   assert(filePath.isDefined ^ data.isDefined, "Either key store path or data must be defined, but not both.")
@@ -38,21 +39,24 @@ final class KeyStoreConfig private[sslconfig](
   def withData(data: Option[String]): KeyStoreConfig = copy(data = data, filePath = None)
   /** Disables `data` – only one of those can be used at any given time. */
   def withFilePath(filePath: Option[String]): KeyStoreConfig = copy(filePath = filePath, data = None)
+  def withOnClassPath(onClassPath: Boolean): KeyStoreConfig = copy(isFileOnClasspath = onClassPath, data = None)
   def withPassword(value: Option[String]): KeyStoreConfig = copy(password = value)
   def withStoreType(value: String): KeyStoreConfig = copy(storeType = value)
 
   private def copy(
     data: Option[String] = data,
     filePath: Option[String] = filePath,
+    isFileOnClasspath: Boolean = isFileOnClasspath,
     password: Option[String] = password,
     storeType: String = storeType): KeyStoreConfig = new KeyStoreConfig(
       data = data,
       filePath = filePath,
+      isFileOnClasspath = isFileOnClasspath,
       password = password,
       storeType = storeType)
 
   override def toString =
-    s"""KeyStoreConfig(${data},${filePath},${password},${storeType})"""
+    s"""KeyStoreConfig(${data},${filePath},${isFileOnClasspath},${password},${storeType})"""
 }
 object KeyStoreConfig {
   def apply(data: Option[String], filePath: Option[String]) = new KeyStoreConfig(data, filePath)
@@ -103,6 +107,7 @@ object TrustManagerConfig {
 final class TrustStoreConfig private[sslconfig](
   val data: Option[String],
   val filePath: Option[String],
+  val isFileOnClasspath: Boolean = false,
   val storeType: String = KeyStore.getDefaultType) {
 
   assert(filePath.isDefined ^ data.isDefined, "Either trust store path or data must be defined, but not both.")
@@ -111,18 +116,21 @@ final class TrustStoreConfig private[sslconfig](
   def withData(data: Option[String]): TrustStoreConfig = copy(data = data, filePath = None)
   /** Disables `data` – only one of those can be used at any given time. */
   def withFilePath(filePath: Option[String]): TrustStoreConfig = copy(filePath = filePath, data = None)
+  def withIsFileOnClasspath(isFileOnClasspath: Boolean): TrustStoreConfig = copy(isFileOnClasspath = isFileOnClasspath, data = None)
   def withStoreType(value: String): TrustStoreConfig = copy(storeType = value)
 
   private def copy(
     data: Option[String] = data,
     filePath: Option[String] = filePath,
+    isFileOnClasspath: Boolean = isFileOnClasspath,
     storeType: String = storeType): TrustStoreConfig = new TrustStoreConfig(
       data = data,
       filePath = filePath,
+      isFileOnClasspath = isFileOnClasspath,
       storeType = storeType)
 
   override def toString =
-    s"""TrustStoreConfig(${data},${filePath},${storeType})"""
+    s"""TrustStoreConfig(${data},${filePath},${isFileOnClasspath},${storeType})"""
 }
 object TrustStoreConfig {
   def apply(data: Option[String], filePath: Option[String]) = new TrustStoreConfig(data, filePath)
@@ -617,10 +625,11 @@ class SSLConfigParser(c: EnrichedConfig, classLoader: ClassLoader) {
   def parseKeyStoreInfo(config: EnrichedConfig): KeyStoreConfig = {
     val storeType = config.getOptional[String]("type").getOrElse(KeyStore.getDefaultType)
     val path = config.getOptional[String]("path")
+    val classPath = config.getOptional[Boolean]("classpath").getOrElse(false)
     val data = config.getOptional[String]("data")
     val password = config.getOptional[String]("password")
 
-    new KeyStoreConfig(filePath = path, storeType = storeType, data = data, password = password)
+    new KeyStoreConfig(filePath = path, storeType = storeType, isFileOnClasspath = classPath, data = data, password = password)
   }
 
   /**
@@ -629,9 +638,10 @@ class SSLConfigParser(c: EnrichedConfig, classLoader: ClassLoader) {
   def parseTrustStoreInfo(config: EnrichedConfig): TrustStoreConfig = {
     val storeType = config.getOptional[String]("type").getOrElse(KeyStore.getDefaultType)
     val path = config.getOptional[String]("path")
+    val classPath = config.getOptional[Boolean]("classpath").getOrElse(false)
     val data = config.getOptional[String]("data")
 
-    new TrustStoreConfig(filePath = path, storeType = storeType, data = data)
+    new TrustStoreConfig(filePath = path, isFileOnClasspath = classPath, storeType = storeType, data = data)
   }
 
   /**

--- a/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/SSLContextBuilder.scala
+++ b/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/SSLContextBuilder.scala
@@ -152,7 +152,12 @@ class ConfigSSLContextBuilder(mkLogger: LoggerFactory,
   def keyStoreBuilder(ksc: KeyStoreConfig): KeyStoreBuilder = {
     val password = ksc.password.map(_.toCharArray)
     ksc.filePath.map { f =>
-      fileBuilder(ksc.storeType, f, password)
+      if (ksc.isFileOnClasspath) {
+        fileOnClasspathBuilder(ksc.storeType, f, password)
+      } else {
+        fileBuilder(ksc.storeType, f, password)
+      }
+
     }.getOrElse {
       val data = ksc.data.getOrElse(throw new IllegalStateException("No keystore builder found!"))
       stringBuilder(data)
@@ -161,7 +166,11 @@ class ConfigSSLContextBuilder(mkLogger: LoggerFactory,
 
   def trustStoreBuilder(tsc: TrustStoreConfig): KeyStoreBuilder = {
     tsc.filePath.map { f =>
-      fileBuilder(tsc.storeType, f, None)
+      if (tsc.isFileOnClasspath) {
+        fileOnClasspathBuilder(tsc.storeType, f, None)
+      } else {
+        fileBuilder(tsc.storeType, f, None)
+      }
     }.getOrElse {
       val data = tsc.data.getOrElse(throw new IllegalStateException("No truststore builder found!"))
       stringBuilder(data)
@@ -170,6 +179,10 @@ class ConfigSSLContextBuilder(mkLogger: LoggerFactory,
 
   def fileBuilder(storeType: String, filePath: String, password: Option[Array[Char]]): KeyStoreBuilder = {
     new FileBasedKeyStoreBuilder(storeType, filePath, password)
+  }
+
+  def fileOnClasspathBuilder(storeType: String, filePath: String, password: Option[Array[Char]]): KeyStoreBuilder = {
+    new FileOnClasspathBasedKeyStoreBuilder(storeType, filePath, password)
   }
 
   def stringBuilder(data: String): KeyStoreBuilder = {

--- a/ssl-config-core/src/test/scala/com/typesafe/sslconfig/ssl/ConfigSSLContextBuilderSpec.scala
+++ b/ssl-config-core/src/test/scala/com/typesafe/sslconfig/ssl/ConfigSSLContextBuilderSpec.scala
@@ -184,6 +184,20 @@ class ConfigSSLContextBuilderSpec extends Specification with Mockito {
       actual must beAnInstanceOf[FileBasedKeyStoreBuilder]
     }
 
+    "build a file on classpath based keystore builder" in {
+      val info = SSLConfigSettings()
+      val keyManagerFactory = mock[KeyManagerFactoryWrapper]
+      val trustManagerFactory = mock[TrustManagerFactoryWrapper]
+      val builder = new ConfigSSLContextBuilder(mkLogger, info, keyManagerFactory, trustManagerFactory)
+
+      val storeType = KeyStore.getDefaultType
+      val filePath = "derp"
+
+      val actual = builder.fileOnClasspathBuilder(storeType, filePath, None)
+      actual must beAnInstanceOf[FileOnClasspathBasedKeyStoreBuilder]
+
+    }
+
     "build a string based keystore builder" in {
       val info = SSLConfigSettings()
       val keyManagerFactory = mock[KeyManagerFactoryWrapper]


### PR DESCRIPTION
fixes #56 

Just a quick stab, let me know if this is sufficient.

usage example:
```
stores = [
      { type = "JKS", path = keystore-in-a-jar.jks, classpath = true }
]
```