### PR TITLE
Modifed CompositeX509KeyManager to support issuers = null

### DIFF
--- a/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/CompositeX509KeyManager.scala
+++ b/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/CompositeX509KeyManager.scala
@@ -8,7 +8,7 @@ import javax.net.ssl.{ SSLEngine, X509ExtendedKeyManager, X509KeyManager }
 import java.security.{ Principal, PrivateKey }
 import java.security.cert.{ CertificateException, X509Certificate }
 import java.net.Socket
-import com.typesafe.sslconfig.util.{ LoggerFactory, NoDepsLogger }
+import com.typesafe.sslconfig.util.LoggerFactory
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -32,7 +32,7 @@ class CompositeX509KeyManager(mkLogger: LoggerFactory, keyManagers: Seq[X509KeyM
   // the same class, i.e. you can't have two X509KeyManagers in the array.
 
   def getClientAliases(keyType: String, issuers: Array[Principal]): Array[String] = {
-    logger.debug(s"getClientAliases: keyType = $keyType, issuers = ${issuers.toSeq}")
+    logger.debug(s"getClientAliases: keyType = $keyType, issuers = ${issuersAsString(issuers)}")
 
     val clientAliases = new ArrayBuffer[String]
     withKeyManagers { keyManager =>
@@ -47,7 +47,7 @@ class CompositeX509KeyManager(mkLogger: LoggerFactory, keyManagers: Seq[X509KeyM
   }
 
   def chooseClientAlias(keyType: Array[String], issuers: Array[Principal], socket: Socket): String = {
-    logger.debug(s"chooseClientAlias: keyType = ${keyType.toSeq}, issuers = ${issuers.toSeq}, socket = $socket")
+    logger.debug(s"chooseClientAlias: keyType = ${keyType.toSeq}, issuers = ${issuersAsString(issuers)}, socket = $socket")
 
     withKeyManagers { keyManager =>
       val clientAlias = keyManager.chooseClientAlias(keyType, issuers, socket)
@@ -60,7 +60,7 @@ class CompositeX509KeyManager(mkLogger: LoggerFactory, keyManagers: Seq[X509KeyM
   }
 
   override def chooseEngineClientAlias(keyType: Array[String], issuers: Array[Principal], engine: SSLEngine): String = {
-    logger.debug(s"chooseEngineClientAlias: keyType = ${keyType.toSeq}, issuers = ${issuers.toSeq}, engine = $engine")
+    logger.debug(s"chooseEngineClientAlias: keyType = ${keyType.toSeq}, issuers = ${issuersAsString(issuers)}, engine = $engine")
     withKeyManagers { keyManager: X509KeyManager =>
       keyManager match {
         case extendedKeyManager: X509ExtendedKeyManager =>
@@ -77,7 +77,7 @@ class CompositeX509KeyManager(mkLogger: LoggerFactory, keyManagers: Seq[X509KeyM
   }
 
   override def chooseEngineServerAlias(keyType: String, issuers: Array[Principal], engine: SSLEngine): String = {
-    logger.debug(s"chooseEngineServerAlias: keyType = ${keyType.toSeq}, issuers = ${issuers.toSeq}, engine = $engine")
+    logger.debug(s"chooseEngineServerAlias: keyType = ${keyType.toSeq}, issuers = ${issuersAsString(issuers)}, engine = $engine")
 
     withKeyManagers { keyManager: X509KeyManager =>
       keyManager match {
@@ -95,7 +95,7 @@ class CompositeX509KeyManager(mkLogger: LoggerFactory, keyManagers: Seq[X509KeyM
   }
 
   def getServerAliases(keyType: String, issuers: Array[Principal]): Array[String] = {
-    logger.debug(s"getServerAliases: keyType = $keyType, issuers = ${issuers.toSeq}")
+    logger.debug(s"getServerAliases: keyType = $keyType, issuers = ${issuersAsString(issuers)}")
 
     val serverAliases = new ArrayBuffer[String]
     withKeyManagers { keyManager =>
@@ -110,7 +110,7 @@ class CompositeX509KeyManager(mkLogger: LoggerFactory, keyManagers: Seq[X509KeyM
   }
 
   def chooseServerAlias(keyType: String, issuers: Array[Principal], socket: Socket): String = {
-    logger.debug(s"chooseServerAlias: keyType = $keyType, issuers = ${issuers.toSeq}, socket = $socket")
+    logger.debug(s"chooseServerAlias: keyType = $keyType, issuers = ${issuersAsString(issuers)}, socket = $socket")
     withKeyManagers { keyManager =>
       val serverAlias = keyManager.chooseServerAlias(keyType, issuers, socket)
       if (serverAlias != null) {
@@ -159,6 +159,10 @@ class CompositeX509KeyManager(mkLogger: LoggerFactory, keyManagers: Seq[X509KeyM
   }
 
   private def nullIfEmpty[T](array: Array[T]) = if (array.size == 0) null else array
+
+  private def issuersAsString(issuers: Array[Principal]) = {
+    Option(issuers).getOrElse(Array.empty[Principal]).toSeq
+  }
 
   override def toString = {
     s"CompositeX509KeyManager(keyManagers = [$keyManagers])"

--- a/ssl-config-core/src/test/scala/com/typesafe/sslconfig/ssl/CompositeX509KeyManagerSpec.scala
+++ b/ssl-config-core/src/test/scala/com/typesafe/sslconfig/ssl/CompositeX509KeyManagerSpec.scala
@@ -48,8 +48,8 @@ object CompositeX509KeyManagerSpec extends Specification with Mockito {
         val issuers = Array[Principal]()
         val engine = mock[SSLEngine]
 
-        val serverAlias = keyManager.chooseEngineClientAlias(keyType = keyType, issuers = issuers, engine = engine)
-        serverAlias must beNull
+        val clientAlias = keyManager.chooseEngineClientAlias(keyType = keyType, issuers = issuers, engine = engine)
+        clientAlias must beNull
       }
 
       "return a result" in {
@@ -59,8 +59,8 @@ object CompositeX509KeyManagerSpec extends Specification with Mockito {
         val issuers = Array[Principal]()
         val engine = mock[SSLEngine]
 
-        val serverAlias = keyManager.chooseEngineClientAlias(keyType = keyType, issuers = issuers, engine = engine)
-        serverAlias must be_==("clientAlias")
+        val clientAlias = keyManager.chooseEngineClientAlias(keyType = keyType, issuers = issuers, engine = engine)
+        clientAlias must be_==("clientAlias")
       }
 
       "return null" in {
@@ -70,8 +70,19 @@ object CompositeX509KeyManagerSpec extends Specification with Mockito {
         val issuers = Array[Principal]()
         val engine = mock[SSLEngine]
 
-        val serverAlias = keyManager.chooseEngineClientAlias(keyType = keyType, issuers = issuers, engine = engine)
-        serverAlias must beNull
+        val clientAlias = keyManager.chooseEngineClientAlias(keyType = keyType, issuers = issuers, engine = engine)
+        clientAlias must beNull
+      }
+
+      "return null when issuers are null" in {
+        val mockKeyManager = mockExtendedX509KeyManager()
+        val keyManager = new CompositeX509KeyManager(mkLogger, Seq(mockKeyManager))
+        val keyType = Array("derp")
+        val issuers = null
+        val engine = mock[SSLEngine]
+
+        val clientAlias = keyManager.chooseEngineClientAlias(keyType = keyType, issuers = issuers, engine = engine)
+        clientAlias must beNull
       }
     }
 
@@ -109,6 +120,17 @@ object CompositeX509KeyManagerSpec extends Specification with Mockito {
         val serverAlias = keyManager.chooseEngineServerAlias(keyType = keyType, issuers = issuers, engine = engine)
         serverAlias must beNull
       }
+
+      "return null when issuers are null" in {
+        val mockKeyManager = mockExtendedX509KeyManager()
+        val keyManager = new CompositeX509KeyManager(mkLogger, Seq(mockKeyManager))
+        val keyType = "derp"
+        val issuers = null
+        val engine = mock[SSLEngine]
+
+        val serverAlias = keyManager.chooseEngineServerAlias(keyType = keyType, issuers = issuers, engine = engine)
+        serverAlias must beNull
+      }
     }
 
     "chooseClientAlias" should {
@@ -121,8 +143,8 @@ object CompositeX509KeyManagerSpec extends Specification with Mockito {
 
         mockKeyManager.chooseClientAlias(keyType, issuers, socket) returns "clientAlias"
 
-        val serverAlias = keyManager.chooseClientAlias(keyType = keyType, issuers = issuers, socket = socket)
-        serverAlias must be_==("clientAlias")
+        val clientAlias = keyManager.chooseClientAlias(keyType = keyType, issuers = issuers, socket = socket)
+        clientAlias must be_==("clientAlias")
       }
 
       "return null" in {
@@ -134,8 +156,21 @@ object CompositeX509KeyManagerSpec extends Specification with Mockito {
 
         mockKeyManager.chooseClientAlias(keyType, issuers, socket) returns null
 
-        val serverAlias = keyManager.chooseClientAlias(keyType = keyType, issuers = issuers, socket = socket)
-        serverAlias must beNull
+        val clientAlias = keyManager.chooseClientAlias(keyType = keyType, issuers = issuers, socket = socket)
+        clientAlias must beNull
+      }
+
+      "return null when issuers are null" in {
+        val mockKeyManager = mock[X509KeyManager]
+        val keyManager = new CompositeX509KeyManager(mkLogger, Seq(mockKeyManager))
+        val keyType = Array("derp")
+        val issuers = null
+        val socket = mock[Socket]
+
+        mockKeyManager.chooseClientAlias(keyType, issuers, socket) returns null
+
+        val clientAlias = keyManager.chooseClientAlias(keyType = keyType, issuers = issuers, socket = socket)
+        clientAlias must beNull
       }
     }
 
@@ -158,6 +193,18 @@ object CompositeX509KeyManagerSpec extends Specification with Mockito {
         val keyManager = new CompositeX509KeyManager(mkLogger, Seq(mockKeyManager))
         val keyType = "derp"
         val issuers = Array[Principal]()
+
+        mockKeyManager.getClientAliases(keyType, issuers) returns null
+
+        val clientAliases = keyManager.getClientAliases(keyType = keyType, issuers = issuers)
+        clientAliases must beNull
+      }
+
+      "return null when issuers are null" in {
+        val mockKeyManager = mock[X509KeyManager]
+        val keyManager = new CompositeX509KeyManager(mkLogger, Seq(mockKeyManager))
+        val keyType = "derp"
+        val issuers = null
 
         mockKeyManager.getClientAliases(keyType, issuers) returns null
 
@@ -190,6 +237,18 @@ object CompositeX509KeyManagerSpec extends Specification with Mockito {
         val serverAliases = keyManager.getServerAliases(keyType = keyType, issuers = issuers)
         serverAliases must beNull
       }
+
+      "return null when issuers are null" in {
+        val mockKeyManager = mock[X509KeyManager]
+        val keyManager = new CompositeX509KeyManager(mkLogger, Seq(mockKeyManager))
+        val keyType = "derp"
+        val issuers = null
+
+        mockKeyManager.getServerAliases(keyType, issuers) returns null
+
+        val serverAliases = keyManager.getServerAliases(keyType = keyType, issuers = issuers)
+        serverAliases must beNull
+      }
     }
 
     "chooseServerAlias" should {
@@ -211,6 +270,19 @@ object CompositeX509KeyManagerSpec extends Specification with Mockito {
         val keyManager = new CompositeX509KeyManager(mkLogger, Seq(mockKeyManager))
         val keyType = "derp"
         val issuers = Array[Principal]()
+        val socket = mock[Socket]
+
+        mockKeyManager.chooseServerAlias(keyType, issuers, socket) returns null
+
+        val serverAlias = keyManager.chooseServerAlias(keyType = keyType, issuers = issuers, socket = socket)
+        serverAlias must beNull
+      }
+
+      "return null when issuers are null" in {
+        val mockKeyManager = mock[X509KeyManager]
+        val keyManager = new CompositeX509KeyManager(mkLogger, Seq(mockKeyManager))
+        val keyType = "derp"
+        val issuers = null
         val socket = mock[Socket]
 
         mockKeyManager.chooseServerAlias(keyType, issuers, socket) returns null


### PR DESCRIPTION
If issuers are null the debug message will cause a Null pointer exception as reported in issue #43  