### PR TITLE
To allow the generated jar be treated as a java9 module named ssl.config.core

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,7 @@ val dontPublishSettings = Seq(
 
 lazy val sslConfigCore = project.in(file("ssl-config-core"))
   .settings(commonSettings: _*)
+  .settings(AutomaticModuleName.settings("ssl.config.core"))
   .settings(osgiSettings: _*)
   .settings(
     name := "ssl-config-core",

--- a/project/AutomaticModuleName.scala
+++ b/project/AutomaticModuleName.scala
@@ -1,0 +1,24 @@
+/**
+  * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+  */
+
+// package akka
+
+import sbt.{Def, _}
+import sbt.Keys._
+
+/**
+  * Helper to set Automatic-Module-Name in projects.
+  *
+  * !! DO NOT BE TEMPTED INTO AUTOMATICALLY DERIVING THE NAMES FROM PROJECT NAMES !!
+  *
+  * The names carry a lot of implications and DO NOT have to always align 1:1 with the group ids or package names,
+  * though there should be of course a strong relationship between them.
+  */
+object AutomaticModuleName  {
+  private val AutomaticModuleName = "Automatic-Module-Name"
+
+  def settings(name: String): Seq[Def.Setting[Task[Seq[PackageOption]]]] = Seq(
+    packageOptions in (Compile, packageBin) += Package.ManifestAttributes(AutomaticModuleName → name)
+  )
+}

--- a/project/AutomaticModuleName.scala
+++ b/project/AutomaticModuleName.scala
@@ -1,8 +1,6 @@
-/**
-  * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
-  */
-
-// package akka
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
 
 import sbt.{Def, _}
 import sbt.Keys._


### PR DESCRIPTION
I just did a quick copy from akka repo. 

Anything needs updated, please let me know