### PR TITLE
Explicitly added requireCapability header. (Fix for #80)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,8 @@ lazy val sslConfigCore = project.in(file("ssl-config-core"))
     ),
     OsgiKeys.bundleSymbolicName := s"${organization.value}.sslconfig",
     OsgiKeys.exportPackage := Seq(s"com.typesafe.sslconfig.*;version=${version.value}"),
-    OsgiKeys.importPackage := Seq("!sun.misc", "!sun.security.*", configImport(), "*")
+    OsgiKeys.importPackage := Seq("!sun.misc", "!sun.security.*", configImport(), "*"),
+    OsgiKeys.requireCapability := """osgi.ee;filter:="(&(osgi.ee=JavaSE)(version>=1.8))""""
   ).enablePlugins(ReleasePlugin, SbtOsgi)
 
 lazy val documentation = project.in(file("documentation"))


### PR DESCRIPTION
The header that was generated automatically for the osgi.ee capability
contained the exact version of the JDK used at build time. With this
fix a header is defined that references a JavaSE version >= 1.8.

Note that the akka libraries follow the same approach.