### PR TITLE
Update trust manager to use extended interface

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,6 +71,9 @@ lazy val sslConfigCore = project.in(file("ssl-config-core"))
       // DefaultHostnameVerifier was decomissioned
       ProblemFilters.exclude[MissingClassProblem]("com.typesafe.sslconfig.ssl.DefaultHostnameVerifier"),
 
+      // Add in extended composite trust manager.
+      ProblemFilters.exclude[MissingTypesProblem]("com.typesafe.sslconfig.ssl.CompositeX509TrustManager"),
+      
       // Delete the whole hacky debug package (plus MonkeyPatcher which should've been debug)
       ProblemFilters.exclude[MissingClassProblem]("com.typesafe.sslconfig.ssl.MonkeyPatcher"),
       ProblemFilters.exclude[MissingClassProblem]("com.typesafe.sslconfig.ssl.debug.*"),

--- a/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/CompositeX509TrustManager.scala
+++ b/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/CompositeX509TrustManager.scala
@@ -9,9 +9,10 @@ import java.security.GeneralSecurityException
 import java.security.cert._
 
 import com.typesafe.sslconfig.util.LoggerFactory
-import javax.net.ssl.{SSLEngine, X509ExtendedTrustManager, X509TrustManager}
+import javax.net.ssl.{ SSLEngine, X509ExtendedTrustManager, X509TrustManager }
 
 import scala.collection.mutable.ArrayBuffer
+import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
 /**
@@ -175,14 +176,14 @@ class CompositeX509TrustManager(mkLogger: LoggerFactory, trustManagers: Seq[X509
     }
   }
 
-  private def withTrustManagers[T](block: T => Unit): Seq[Throwable] = {
+  private def withTrustManagers[T <: X509TrustManager: ClassTag](block: T => Unit): Seq[Throwable] = {
     val exceptionList = ArrayBuffer[Throwable]()
     trustManagers.foreach {
       trustManager =>
         try {
           trustManager match {
-            case t: T =>
-              block(trustManager)
+            case tr: T =>
+              block(tr)
             case _ =>
               throw new IllegalStateException("Trust manager does not extend X509ExtendedTrustManager interface!")
           }

--- a/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/CompositeX509TrustManager.scala
+++ b/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/CompositeX509TrustManager.scala
@@ -4,7 +4,9 @@
 
 package com.typesafe.sslconfig.ssl
 
-import javax.net.ssl.X509TrustManager
+import java.net.Socket
+
+import javax.net.ssl.{ SSLEngine, X509ExtendedTrustManager, X509TrustManager }
 import java.security.cert._
 
 import com.typesafe.sslconfig.util.LoggerFactory
@@ -17,42 +19,76 @@ import java.security.GeneralSecurityException
  * A trust manager that is a composite of several smaller trust managers.   It is responsible for verifying the
  * credentials received from a peer.
  */
-class CompositeX509TrustManager(mkLogger: LoggerFactory, trustManagers: Seq[X509TrustManager], algorithmChecker: AlgorithmChecker) extends X509TrustManager {
+class CompositeX509TrustManager(mkLogger: LoggerFactory, trustManagers: Seq[X509TrustManager], algorithmChecker: AlgorithmChecker) extends X509ExtendedTrustManager {
 
   private val logger = mkLogger(getClass)
 
   def getAcceptedIssuers: Array[X509Certificate] = {
     logger.debug("getAcceptedIssuers: ")
     val certificates = ArrayBuffer[X509Certificate]()
-    val exceptionList = withTrustManagers {
+    val exceptionList = withTrustManagers[X509TrustManager] {
       trustManager =>
         certificates ++= trustManager.getAcceptedIssuers
     }
     // getAcceptedIssuers should never throw an exception.
-    if (!exceptionList.isEmpty) {
-      val msg = exceptionList(0).getMessage
+    if (exceptionList.nonEmpty) {
+      val msg = exceptionList.head.getMessage
       throw new CompositeCertificateException(msg, exceptionList.toArray)
     }
     certificates.toArray
   }
 
-  // In 1.7, sun.security.ssl.X509TrustManagerImpl extends from javax.net.ssl.X509ExtendedTrustManager.
-  // The two X509ExtendedTrustManager contain different method signatures, and both are available in 1.7, which means
-  // it's really hard to keep something backwards compatible if something is calling trustManager.asInstanceOf[X509ExtendedTrustManager]
-  // internally.  For now, we have to trust that the internal API holds to the X509TrustManager interface.
-  //
-  //def checkClientTrusted(chain: Array[X509Certificate], authType: String, hostname: String, algorithm: String): Unit = ???
-  //def checkServerTrusted(chain: Array[X509Certificate], authType: String, hostname: String, algorithm: String): Unit = ???
-
-  def checkClientTrusted(chain: Array[X509Certificate], authType: String): Unit = {
-    logger.debug(s"checkClientTrusted: chain = ${debugChain(chain)}")
+  override def checkClientTrusted(chain: Array[X509Certificate], authType: String, socket: Socket): Unit = {
+    logger.debug(s"checkClientTrusted: chain = ${debugChain(chain)}, authType = $authType, socket = $socket")
 
     val anchor: TrustAnchor = new TrustAnchor(chain(chain.length - 1), null)
     logger.debug(s"checkClientTrusted: checking key size only on root anchor $anchor")
     algorithmChecker.checkKeyAlgorithms(anchor.getTrustedCert)
 
     var trusted = false
-    val exceptionList = withTrustManagers {
+    val exceptionList = withTrustManagers[X509ExtendedTrustManager] {
+      trustManager =>
+        trustManager.checkClientTrusted(chain, authType, socket)
+        logger.debug(s"checkClientTrusted: trustManager $trustManager found a match for ${debugChain(chain)}")
+        trusted = true
+    }
+
+    if (!trusted) {
+      val msg = "No trust manager was able to validate this certificate chain."
+      throw new CompositeCertificateException(msg, exceptionList.toArray)
+    }
+  }
+
+  override def checkClientTrusted(chain: Array[X509Certificate], authType: String, sslEngine: SSLEngine): Unit = {
+    logger.debug(s"checkClientTrusted: chain = ${debugChain(chain)}, authType = $authType, sslEngine = $sslEngine")
+
+    val anchor: TrustAnchor = new TrustAnchor(chain(chain.length - 1), null)
+    logger.debug(s"checkClientTrusted: checking key size only on root anchor $anchor")
+    algorithmChecker.checkKeyAlgorithms(anchor.getTrustedCert)
+
+    var trusted = false
+    val exceptionList = withTrustManagers[X509ExtendedTrustManager] {
+      trustManager =>
+        trustManager.checkClientTrusted(chain, authType, sslEngine)
+        logger.debug(s"checkClientTrusted: trustManager $trustManager found a match for ${debugChain(chain)}")
+        trusted = true
+    }
+
+    if (!trusted) {
+      val msg = "No trust manager was able to validate this certificate chain."
+      throw new CompositeCertificateException(msg, exceptionList.toArray)
+    }
+  }
+
+  def checkClientTrusted(chain: Array[X509Certificate], authType: String): Unit = {
+    logger.debug(s"checkClientTrusted: chain = ${debugChain(chain)}, authType = $authType")
+
+    val anchor: TrustAnchor = new TrustAnchor(chain(chain.length - 1), null)
+    logger.debug(s"checkClientTrusted: checking key size only on root anchor $anchor")
+    algorithmChecker.checkKeyAlgorithms(anchor.getTrustedCert)
+
+    var trusted = false
+    val exceptionList = withTrustManagers[X509TrustManager] {
       trustManager =>
         trustManager.checkClientTrusted(chain, authType)
         logger.debug(s"checkClientTrusted: trustManager $trustManager found a match for ${debugChain(chain)}")
@@ -76,7 +112,7 @@ class CompositeX509TrustManager(mkLogger: LoggerFactory, trustManagers: Seq[X509
     algorithmChecker.checkKeyAlgorithms(anchor.getTrustedCert)
 
     var trusted = false
-    val exceptionList = withTrustManagers {
+    val exceptionList = withTrustManagers[X509TrustManager] {
       trustManager =>
         // always run through the trust manager before making any decisions
         trustManager.checkServerTrusted(chain, authType)
@@ -90,12 +126,62 @@ class CompositeX509TrustManager(mkLogger: LoggerFactory, trustManagers: Seq[X509
     }
   }
 
-  private def withTrustManagers(block: (X509TrustManager => Unit)): Seq[Throwable] = {
+  override def checkServerTrusted(chain: Array[X509Certificate], authType: String, socket: Socket): Unit = {
+    logger.debug(s"checkServerTrusted: chain = ${debugChain(chain)}, authType = $authType, socket = $socket")
+
+    // Trust anchor is at the end of the chain... there is no way to pass a trust anchor
+    // through to a checker in PKIXCertPathValidator.doValidate(), so the trust manager is the
+    // last place we have access to it.
+    val anchor: TrustAnchor = new TrustAnchor(chain(chain.length - 1), null)
+    logger.debug(s"checkServerTrusted: checking key size only on root anchor $anchor")
+    algorithmChecker.checkKeyAlgorithms(anchor.getTrustedCert)
+
+    var trusted = false
+    val exceptionList = withTrustManagers[X509ExtendedTrustManager] {
+      trustManager =>
+        // always run through the trust manager before making any decisions
+        trustManager.checkServerTrusted(chain, authType, socket)
+        logger.debug(s"checkServerTrusted: trustManager $trustManager using authType $authType found a match for ${debugChain(chain).toSeq}")
+        trusted = true
+    }
+
+    if (!trusted) {
+      val msg = s"No trust manager was able to validate this certificate chain: # of exceptions = ${exceptionList.size}"
+      throw new CompositeCertificateException(msg, exceptionList.toArray)
+    }
+  }
+
+  override def checkServerTrusted(chain: Array[X509Certificate], authType: String, sslEngine: SSLEngine): Unit = {
+    logger.debug(s"checkServerTrusted: chain = ${debugChain(chain)}, authType = $authType, sslEngine = $sslEngine")
+
+    // Trust anchor is at the end of the chain... there is no way to pass a trust anchor
+    // through to a checker in PKIXCertPathValidator.doValidate(), so the trust manager is the
+    // last place we have access to it.
+    val anchor: TrustAnchor = new TrustAnchor(chain(chain.length - 1), null)
+    logger.debug(s"checkServerTrusted: checking key size only on root anchor $anchor")
+    algorithmChecker.checkKeyAlgorithms(anchor.getTrustedCert)
+
+    var trusted = false
+    val exceptionList = withTrustManagers[X509ExtendedTrustManager] {
+      trustManager =>
+        // always run through the trust manager before making any decisions
+        trustManager.checkServerTrusted(chain, authType, sslEngine)
+        logger.debug(s"checkServerTrusted: trustManager $trustManager using authType $authType found a match for ${debugChain(chain).toSeq}")
+        trusted = true
+    }
+
+    if (!trusted) {
+      val msg = s"No trust manager was able to validate this certificate chain: # of exceptions = ${exceptionList.size}"
+      throw new CompositeCertificateException(msg, exceptionList.toArray)
+    }
+  }
+
+  private def withTrustManagers[T](block: T => Unit): Seq[Throwable] = {
     val exceptionList = ArrayBuffer[Throwable]()
     trustManagers.foreach {
       trustManager =>
         try {
-          block(trustManager)
+          block(trustManager.asInstanceOf[T])
         } catch {
           case e: CertPathBuilderException =>
             logger.debug(s"No path found to certificate: this usually means the CA is not in the trust store. Cause: $e")
@@ -114,4 +200,5 @@ class CompositeX509TrustManager(mkLogger: LoggerFactory, trustManagers: Seq[X509
   override def toString = {
     s"CompositeX509TrustManager(trustManagers = [$trustManagers], algorithmChecker = $algorithmChecker)"
   }
+
 }


### PR DESCRIPTION
Updates the trust manager to use `ExtendedX509TrustManager`, which is the underlying type for JSSE for a while now.