### PR TITLE
Use sbt-release to do releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SSL Config
 
 Goal and purpose of this library is to make Play's WS library as well as Akka HTTP "secure by default".
 Sadly, while Java's security has been steadily improving some settings are still left up to the user,
-and certain algorithms which should never be used in a serious prodution system are still accepted by 
+and certain algorithms which should never be used in a serious production system are still accepted by 
 the default settings of the SSL/TLS infrastructure. These things are possible to fix, by providing specialized 
 implementations and/or defining additional settings for the Java runtime to use – this is exactly the purpose of SSL Config.
 
@@ -24,9 +24,9 @@ The project is maintained on two branches:
 
 Latest versions:
 
-```
+```scala
 // JDK8: 
-"com.typesafe" %% "ssl-config-akka" % "0.2.2"
+"com.typesafe" %% "ssl-config-akka" % "0.2.4"
 ```
 
 State of this project
@@ -58,6 +58,11 @@ An excellent series by [Will Sargent](https://github.com/wsargent) about making
 - [Fixing Certificate Revocation](https://tersesystems.com/blog/2014/03/22/fixing-certificate-revocation/)
 - [Fixing Hostname Verification](https://tersesystems.com/blog/2014/03/23/fixing-hostname-verification/) 
 - [Testing Hostname Verification](https://tersesystems.com/blog/2014/03/31/testing-hostname-verification)
+
+Releasing
+=========
+
+Run `release.sh` script.
 
 License
 =======

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,6 +8,7 @@ addSbtPlugin("org.scalariform"       % "sbt-scalariform"     % "1.8.2")
 addSbtPlugin("com.typesafe.sbt"      % "sbt-site"            % "1.3.2")
 
 addSbtPlugin("de.heikoseeberger"     % "sbt-header"          % "5.0.0")
+addSbtPlugin("org.xerial.sbt"        % "sbt-sonatype"        % "2.3")
 addSbtPlugin("io.crashbox"           % "sbt-gpg"             % "0.2.0")
 addSbtPlugin("com.typesafe"          % "sbt-mima-plugin"     % "0.3.0")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox"         % "0.2.13")

--- a/release.sh
+++ b/release.sh
@@ -26,6 +26,6 @@ git commit -m "Releasing docs for version $version"
 git push origin gh-pages
 
 echo "Docs where published. Getting back to release branch."
-git cd -
+git checkout -
 
 echo "[RELEASE SUCCESSFUL]"

--- a/release.sh
+++ b/release.sh
@@ -1,53 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# print usage info
-function usage {
-  cat <<EOM
-Usage: ${script_name} VERSION
-EOM
-}
+echo "Starting release. You will be prompt to confirm the version and push changes at the end of the process"
+sbt 'release cross'
 
-# fail the script with an error message
-function fail {
-  echoerr "$@"
-  exit 1
-}
+# Get the latest tag which is the one created above
+version=$(git tag --sort=-taggerdate | head -1)
 
-# echo an error message
-function echoerr {
-  echo "[${script_name}] $@" 1>&2
-}
-
-if [ $# != "1" ]; then
-  usage
-  fail "A release version must be specified"
-fi
-
-# get the current project version from sbt
-# a little messy as the ansi escape codes are included
-function get_current_version {
-  local result=$(sbt version | grep -v warn | tail -1 | cut -f2)
-  # remove ansi escape code from end
-  local code0=$(echo -e "\033[0m")
-  echo ${result%$code0}
-}
-
-(read -p "The working directory will now be cleaned from all non-tracked files. Are you sure you want this? " x; test "$x" = yes) || fail "bailing out"
-git clean -fxd || fail "cannot git clean -fxd"
-
-declare -r currentVersion=$(get_current_version)
-declare -r version=$1
-
-echo "Updating version.sbt to $version..."
-sed -i "s/$currentVersion/$version/" version.sbt
-git commit version.sbt -m "Update version to $version"
-
-echo "Publishing artifacts..."
-sbt '+publishSigned'
-
-echo "Publishing docs..."
+echo "Publishing documentation for version $version"
 sbt makeSite
-mv documentation/target/site ../releasing-the-docs
+mv -v documentation/target/site ../releasing-the-docs
+
 git checkout gh-pages
 rm -rf *
 mv ../releasing-the-docs docs
@@ -55,13 +17,10 @@ mv docs/* .
 rm -rf docs
 touch .nojekyll
 git add .
-git commit -m "Releasing docs for $version"
+git commit -m "Releasing docs for version $version"
 git push origin gh-pages
 
-echo "Tagging release..."
-git tag -m "Releasing $version" "v$version"
-git push --tags
-
-git checkout master
+echo "Docs where published. Getting back to release branch."
+git cd -
 
 echo "[RELEASE SUCCESSFUL]"

--- a/release.sh
+++ b/release.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# Clean up the directory of local changes so that we can be sure
+# the HEAD from release branch is used to run the release.
+(read -p "The working directory will now be cleaned from all non-tracked files. Are you sure you want this? " x; test "$x" = yes) || fail "bailing out"
+git clean -fxd || fail "cannot git clean -fxd"
+
 echo "Starting release. You will be prompt to confirm the version and push changes at the end of the process"
 sbt 'release cross'
 


### PR DESCRIPTION
Instead of using a script which only runs `+publishSigned` use
the full release process from sbt-release, including sonatype
promotion of artifacts.

Follow up to #95.

Depends on #103.