### PR TITLE
FakeKS restored to self-signed. Add FakeChainedKS.

### DIFF
--- a/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/FakeSSLTools.scala
+++ b/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/FakeSSLTools.scala
@@ -8,9 +8,15 @@ import java.security.KeyStore
 
 import javax.net.ssl._
 
-/** Extracted reusable tools from `play.it.test.ServerEndpoint.SelfSigned`. */
 object FakeSSLTools {
-  /** NOT FOR PRODUCTION USE. */
+  /**
+   * NOT FOR PRODUCTION USE. Builds a "TLS" `SSLContext` and `X509TrustManager` initializing both with the keys and
+   * certificates in the provided `KeyStore`. This means the `SSLContext` will produce `SSLEngine`'s, `SSLSocket``s
+   * and `SSLServerSocket`'s that will use a `KeyPair` from the `KeyStore`, and will trust any  `trustedCertEntry`
+   * in the `KeyStore`.
+   *
+   * This is a naïve implementation for testing purposes only.
+   */
   def buildContextAndTrust(keyStore: KeyStore): (SSLContext, X509TrustManager) = {
     val kmf: KeyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm)
     kmf.init(keyStore, Array.emptyCharArray)

--- a/ssl-config-core/src/test/scala/com/typesafe/sslconfig/ssl/ConfigSSLContextBuilderSpec.scala
+++ b/ssl-config-core/src/test/scala/com/typesafe/sslconfig/ssl/ConfigSSLContextBuilderSpec.scala
@@ -66,8 +66,7 @@ class ConfigSSLContextBuilderSpec extends Specification with Mockito {
       val keyPairGenerator = KeyPairGenerator.getInstance("RSA")
       keyPairGenerator.initialize(2048) // 2048 is the NIST acceptable key length until 2030
       val keyPair = keyPairGenerator.generateKeyPair()
-      val certificateAuthorityKeyPair = keyPairGenerator.generateKeyPair()
-      val cert = FakeKeyStore.createSelfSignedCertificate(keyPair, certificateAuthorityKeyPair)
+      val cert = FakeKeyStore.createSelfSignedCertificate(keyPair)
       val password = "changeit" // cannot have a null password for PKCS12 in 1.6
       keyStore.load(null, password.toCharArray)
       keyStore.setKeyEntry("playgenerated", keyPair.getPrivate, password.toCharArray, Array(cert))
@@ -258,10 +257,9 @@ class ConfigSSLContextBuilderSpec extends Specification with Mockito {
       val keyPairGenerator = KeyPairGenerator.getInstance("RSA")
       keyPairGenerator.initialize(2048) // 2048 is the NIST acceptable key length until 2030
       val keyPair = keyPairGenerator.generateKeyPair()
-      val certificateAuthorityKeyPair = keyPairGenerator.generateKeyPair()
 
       // Generate a self signed certificate
-      val cert = FakeKeyStore.createSelfSignedCertificate(keyPair, certificateAuthorityKeyPair)
+      val cert = FakeKeyStore.createSelfSignedCertificate(keyPair)
 
       val password = "changeit" // null passwords throw exception in 1.6
       keyStore.load(null, password.toCharArray)
@@ -288,10 +286,9 @@ class ConfigSSLContextBuilderSpec extends Specification with Mockito {
       val keyPairGenerator = KeyPairGenerator.getInstance("RSA")
       keyPairGenerator.initialize(2048) // 2048 is the NIST acceptable key length until 2030
       val keyPair = keyPairGenerator.generateKeyPair()
-      val certificateAuthorityKeyPair = keyPairGenerator.generateKeyPair()
 
       // Generate a self signed certificate
-      val cert = FakeKeyStore.createSelfSignedCertificate(keyPair, certificateAuthorityKeyPair)
+      val cert = FakeKeyStore.createSelfSignedCertificate(keyPair)
 
       val password = "changeit" // null passwords throw exception in 1.6 in PKCS12
       keyStore.load(null, password.toCharArray)


### PR DESCRIPTION
Using a keyStore with multiple `privateKeyPair` entries to create an `SSLContext` with a default `KeyManagerFactory` has the consequence that you can't set what key should be used. There are [mechanisms](https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html#SNIServerName) to setup SNI or to [allow connection-specific](https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html#X509ExtendedKeyManager) key selection. Until those are necessary and implemented, using a single-key `KeyStore` is the simplest option.

Note: we could create a collection of tools to create several `KeyStore`'s (one for the CA, another for the server, a third one for client-side SSL auth) but that's not the purpose of this PR.

Fixes #115 