### PR TITLE
Rollsback the default format of FakeKeyStore to JKS

### DIFF
--- a/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/FakeChainedKeyStore.scala
+++ b/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/FakeChainedKeyStore.scala
@@ -67,7 +67,7 @@ object FakeChainedKeyStore {
     val SignatureAlgorithmName = "SHA256withRSA"
     val KeyPairAlgorithmName = "RSA"
     val KeyPairKeyLength = 2048 // 2048 is the NIST acceptable key length until 2030
-    val KeystoreType = "PKCS12"
+    val KeystoreType = "JKS"
     val SignatureAlgorithmOID: ObjectIdentifier = AlgorithmId.sha256WithRSAEncryption_oid
     val keystorePassword: Array[Char] = EMPTY_PASSWORD
   }
@@ -217,7 +217,7 @@ final class FakeChainedKeyStore(mkLogger: LoggerFactory) {
     val keyStore: KeyStore = KeyStore.getInstance(KeystoreSettings.KeystoreType)
     val in = java.nio.file.Files.newInputStream(file.toPath)
     try {
-      keyStore.load(in, "".toCharArray)
+      keyStore.load(in, KeystoreSettings.keystorePassword)
     } finally {
       closeQuietly(in)
     }

--- a/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/FakeKeyStore.scala
+++ b/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/FakeKeyStore.scala
@@ -51,7 +51,7 @@ object FakeKeyStore {
     val SignatureAlgorithmName = "SHA256withRSA"
     val KeyPairAlgorithmName = "RSA"
     val KeyPairKeyLength = 2048 // 2048 is the NIST acceptable key length until 2030
-    val KeystoreType = "PKCS12"
+    val KeystoreType = "JKS"
     val SignatureAlgorithmOID: ObjectIdentifier = AlgorithmId.sha256WithRSAEncryption_oid
     val keystorePassword: Array[Char] = EMPTY_PASSWORD
   }

--- a/ssl-config-core/src/test/scala/com/typesafe/sslconfig/ssl/FakeKeyStoreSpec.scala
+++ b/ssl-config-core/src/test/scala/com/typesafe/sslconfig/ssl/FakeKeyStoreSpec.scala
@@ -4,9 +4,13 @@
 
 package com.typesafe.sslconfig.ssl
 
-import com.typesafe.sslconfig.util.NoopLogger
+import java.io.File
+import java.nio.file.{ Files, Path }
 
+import com.typesafe.sslconfig.util.NoopLogger
 import org.specs2.mutable.Specification
+
+import scala.util.Try
 
 class FakeKeyStoreSpec extends Specification {
   val mkLogger = NoopLogger.factory()
@@ -22,6 +26,55 @@ class FakeKeyStoreSpec extends Specification {
       val actual = new FakeKeyStore(mkLogger).certificateTooWeak(strongCert)
       actual must beFalse
     }
+
+    "build a keystore with a selfsigned certificate and trust on that certificate" in {
+      // create and persist a key store
+      val fakeKeyStore = new FakeKeyStore(mkLogger)
+      val basePath = Files.createTempDirectory("fake-keystore-spec-").toFile
+      val ksPath = fakeKeyStore.getKeyStoreFilePath(basePath)
+      fakeKeyStore.createKeyStore(basePath)
+
+      // load the persisted key store
+      val fakeKeyStore2 = new FakeKeyStore(mkLogger)
+      val keyStore = fakeKeyStore2.createKeyStore(basePath)
+      try {
+        import scala.collection.JavaConverters._
+        val certificates = keyStore.aliases().asScala.flatMap {
+          alias =>
+            Try(keyStore.getCertificate(alias)).toOption
+        }
+        certificates.size must be_>(1)
+      } finally {
+        ksPath.delete()
+      }
+    }
+
+    "build a keystore that's compatible with sslconfig.KeyStore" in {
+      // create and persist a key store
+      val fakeKeyStore = new FakeKeyStore(mkLogger)
+      val basePath = Files.createTempDirectory("fake-keystore-spec-").toFile
+      val ksPath = fakeKeyStore.getKeyStoreFilePath(basePath)
+      fakeKeyStore.createKeyStore(basePath)
+
+
+      // load the persisted key store using sslconfig.KeyStore
+      val keyStore = new FileBasedKeyStoreBuilder(
+        FakeKeyStore.KeystoreSettings.KeystoreType,
+        ksPath.getAbsolutePath,
+        Some(FakeKeyStore.KeystoreSettings.keystorePassword)
+      ).build()
+      try {
+        import scala.collection.JavaConverters._
+        val certificates = keyStore.aliases().asScala.flatMap {
+          alias =>
+            Try(keyStore.getCertificate(alias)).toOption
+        }
+        certificates.size must be_==(1)
+      } finally {
+        ksPath.delete()
+      }
+    }
+
   }
 
 }

--- a/ssl-config-core/src/test/scala/com/typesafe/sslconfig/ssl/FakeKeyStoreSpec.scala
+++ b/ssl-config-core/src/test/scala/com/typesafe/sslconfig/ssl/FakeKeyStoreSpec.scala
@@ -4,8 +4,7 @@
 
 package com.typesafe.sslconfig.ssl
 
-import java.io.File
-import java.nio.file.{ Files, Path }
+import java.nio.file.Files
 
 import com.typesafe.sslconfig.util.NoopLogger
 import org.specs2.mutable.Specification
@@ -43,7 +42,7 @@ class FakeKeyStoreSpec extends Specification {
           alias =>
             Try(keyStore.getCertificate(alias)).toOption
         }
-        certificates.size must be_>(1)
+        certificates.size must be_==(2) // the self-signed and the trusted
       } finally {
         ksPath.delete()
       }
@@ -69,7 +68,7 @@ class FakeKeyStoreSpec extends Specification {
           alias =>
             Try(keyStore.getCertificate(alias)).toOption
         }
-        certificates.size must be_==(1)
+        certificates.size must be_==(2) // the self-signed and the trusted
       } finally {
         ksPath.delete()
       }

--- a/ssl-config-core/src/test/scala/com/typesafe/sslconfig/ssl/FakeKeyStoreSpec.scala
+++ b/ssl-config-core/src/test/scala/com/typesafe/sslconfig/ssl/FakeKeyStoreSpec.scala
@@ -55,7 +55,6 @@ class FakeKeyStoreSpec extends Specification {
       val ksPath = fakeKeyStore.getKeyStoreFilePath(basePath)
       fakeKeyStore.createKeyStore(basePath)
 
-
       // load the persisted key store using sslconfig.KeyStore
       val keyStore = new FileBasedKeyStoreBuilder(
         FakeKeyStore.KeystoreSettings.KeystoreType,


### PR DESCRIPTION
This rollback is caused by #92 not being merged. Building PKCS12 trustStores in FakeKeyStore 
surfaced the bug fixed in #92.