### PR TITLE
Remove sbt-native-packager

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,10 @@
 resolvers += Resolver.url("sbts3 ivy resolver", url("https://dl.bintray.com/emersonloureiro/sbt-plugins"))(Resolver.ivyStylePatterns)
 
 addSbtPlugin("com.github.gseitz"     % "sbt-release"         % "1.0.10")
-addSbtPlugin("com.typesafe.sbt"      % "sbt-native-packager" % "1.3.15")
 addSbtPlugin("com.typesafe.sbt"      % "sbt-osgi"            % "0.9.4")
 addSbtPlugin("cf.janga"              % "sbts3"               % "0.10.3")
 addSbtPlugin("org.scalariform"       % "sbt-scalariform"     % "1.8.2")
 addSbtPlugin("com.typesafe.sbt"      % "sbt-site"            % "1.3.2")
-
 addSbtPlugin("de.heikoseeberger"     % "sbt-header"          % "5.0.0")
 addSbtPlugin("org.xerial.sbt"        % "sbt-sonatype"        % "2.3")
 addSbtPlugin("com.jsuereth"          % "sbt-pgp"             % "1.1.2")


### PR DESCRIPTION
From the history depending on this comes from the very first commit
(26ce7c5d0903eea70de34d5a775279bc4a9ef810) but AFAICT it didn't make use
of it in that commit.  And it doesn't make use of it now, either (again,
AFAICT).  So let's get rid of it.