### PR TITLE
Set version to 0.4.0-SNAPSHOT

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.8-SNAPSHOT"
+version in ThisBuild := "0.4.0-SNAPSHOT"


### PR DESCRIPTION
There's a number of binary incompatible changes in `master`, so it would be easier to handle the release as `0.4.0` rather than `0.3.8`.

In particular, https://github.com/lightbend/ssl-config/pull/143 and https://github.com/lightbend/ssl-config/pull/89 are binary incompatible with previous versions.