### PR TITLE
remove unused sbt plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,5 @@
-resolvers += Resolver.url("sbts3 ivy resolver", url("https://dl.bintray.com/emersonloureiro/sbt-plugins"))(Resolver.ivyStylePatterns)
-
 addSbtPlugin("com.github.gseitz"     % "sbt-release"         % "1.0.11")
 addSbtPlugin("com.typesafe.sbt"      % "sbt-osgi"            % "0.9.4")
-addSbtPlugin("cf.janga"              % "sbts3"               % "0.10.3")
 addSbtPlugin("org.scalariform"       % "sbt-scalariform"     % "1.8.2")
 addSbtPlugin("com.typesafe.sbt"      % "sbt-site"            % "1.3.2")
 addSbtPlugin("de.heikoseeberger"     % "sbt-header"          % "5.0.0")


### PR DESCRIPTION
this came up in the community build. since the plugin requires
a custom resolver to get, it's a pain in that context.