### PR TITLE
Only insert tracing context when debugging is used

### DIFF
--- a/documentation/src/main/paradox/DebuggingSSL.md
+++ b/documentation/src/main/paradox/DebuggingSSL.md
@@ -2,6 +2,16 @@
 
 In the event that an HTTPS connection does not go through, debugging JSSE can be a hassle.
 
+@@@ warning
+
+Enabling debugging wraps the regular SSLContext into a tracing SSLContext.
+This means any code that relied on `instanceOf` checks of the old SSLContext
+will start behaving differently when debugging is enabled.
+For example this appears to be the case when trying to use this module
+with the Jetty ALPN agent.
+
+@@@
+
 @@@ note
 
 Prior to 0.4.0, the debug system relied on undocumented modification of internal JSSE debug settings that were normally set using

--- a/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/SSLContextBuilder.scala
+++ b/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/SSLContextBuilder.scala
@@ -122,7 +122,8 @@ class ConfigSSLContextBuilder(
     } else Nil
 
     val context = buildSSLContext(info.protocol, keyManagers, trustManagers, info.secureRandom)
-    new TracingSSLContext(context, info.debug)(mkLogger)
+    if (info.debug.enabled) new TracingSSLContext(context, info.debug)(mkLogger)
+    else context
   }
 
   def buildSSLContext(

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.0-941c4109bfaea80232b2b5091259e29527ea2abb"
+version in ThisBuild := "0.4.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.0-SNAPSHOT"
+version in ThisBuild := "0.4.0-941c4109bfaea80232b2b5091259e29527ea2abb"


### PR DESCRIPTION
The intermediate TracingSSLContext may cause problems for example with ALPN
negotiation in some cases