### PR TITLE
    Updated the dependency on com.typesafe.config to 1.4.0 to 1.5.0.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,7 @@ releaseProcess := Seq[ReleaseStep](
   pushChanges
 )
 
-def configImport(packageName: String = "com.typesafe.config.*") = versionedImport(packageName, "1.3.0", "1.4.0")
+def configImport(packageName: String = "com.typesafe.config.*") = versionedImport(packageName, "1.4.0", "1.5.0")
 def versionedImport(packageName: String, lower: String, upper: String) = s"""$packageName;version="[$lower,$upper)""""
 
 lazy val checkCodeFormat = taskKey[Unit]("Check that code format is following Scalariform rules")


### PR DESCRIPTION
Brings it inline with the rest of the Akka 2.6 release.

Otherwise if you are using akkk.stream 2.6 and akka.http 10.1.11 there is an
unresolvable dependency chain between the  config 1.3.x release and the 1.4.x release.

Problem occurs using OSGI.

