### PR TITLE
Enable build on JDK 15

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,9 @@ lazy val sslConfigCore = project.in(file("ssl-config-core"))
       "0.4.2",
     ))).map("com.typesafe" %% "ssl-config-core" % _), // "sbt mimaReportBinaryIssues"
     mimaBinaryIssueFilters ++= Seq(
-      ProblemFilters.exclude[IncompatibleSignatureProblem]("com.typesafe.sslconfig.ssl.AlgorithmConstraintsParser.*")
+      ProblemFilters.exclude[IncompatibleSignatureProblem]("com.typesafe.sslconfig.ssl.AlgorithmConstraintsParser.*"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.typesafe.sslconfig.ssl.FakeKeyStore#KeystoreSettings.SignatureAlgorithmOID"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.typesafe.sslconfig.ssl.FakeChainedKeyStore#KeystoreSettings.SignatureAlgorithmOID")
     ),
     libraryDependencies += Library.parserCombinators(scalaVersion.value),
     libraryDependencies ++= Dependencies.sslConfigCore,

--- a/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/FakeChainedKeyStore.scala
+++ b/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/FakeChainedKeyStore.scala
@@ -68,7 +68,6 @@ object FakeChainedKeyStore {
     val KeyPairAlgorithmName = "RSA"
     val KeyPairKeyLength = 2048 // 2048 is the NIST acceptable key length until 2030
     val KeystoreType = "JKS"
-    val SignatureAlgorithmOID: ObjectIdentifier = AlgorithmId.sha256WithRSAEncryption_oid
     val keystorePassword: Array[Char] = EMPTY_PASSWORD
   }
 
@@ -126,7 +125,7 @@ object FakeChainedKeyStore {
 
     // Key and algorithm
     certInfo.set(X509CertInfo.KEY, new CertificateX509Key(userKeyPair.getPublic))
-    val algorithm = new AlgorithmId(KeystoreSettings.SignatureAlgorithmOID)
+    val algorithm = AlgorithmId.get("SHA256WithRSA")
     certInfo.set(X509CertInfo.ALGORITHM_ID, new CertificateAlgorithmId(algorithm))
 
     // Create a new certificate and sign it
@@ -161,7 +160,7 @@ object FakeChainedKeyStore {
 
     // Key and algorithm
     certInfo.set(X509CertInfo.KEY, new CertificateX509Key(keyPair.getPublic))
-    val algorithm = new AlgorithmId(KeystoreSettings.SignatureAlgorithmOID)
+    val algorithm = AlgorithmId.get("SHA256WithRSA")
     certInfo.set(X509CertInfo.ALGORITHM_ID, new CertificateAlgorithmId(algorithm))
 
     val caExtension = new CertificateExtensions

--- a/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/FakeKeyStore.scala
+++ b/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/FakeKeyStore.scala
@@ -4,7 +4,8 @@
 
 package com.typesafe.sslconfig.ssl
 
-import java.security.{ KeyStore, SecureRandom, KeyPairGenerator, KeyPair }
+import java.security.{ KeyPair, KeyPairGenerator, KeyStore, SecureRandom }
+
 import com.typesafe.sslconfig.util.{ LoggerFactory, NoDepsLogger }
 import sun.security.x509._
 import sun.security.util.ObjectIdentifier
@@ -12,6 +13,7 @@ import java.util.Date
 import java.math.BigInteger
 import java.security.cert.X509Certificate
 import java.io._
+
 import javax.net.ssl.KeyManagerFactory
 import java.security.interfaces.RSAPublicKey
 
@@ -52,7 +54,6 @@ object FakeKeyStore {
     val KeyPairAlgorithmName = "RSA"
     val KeyPairKeyLength = 2048 // 2048 is the NIST acceptable key length until 2030
     val KeystoreType = "JKS"
-    val SignatureAlgorithmOID: ObjectIdentifier = AlgorithmId.sha256WithRSAEncryption_oid
     val keystorePassword: Array[Char] = EMPTY_PASSWORD
   }
 
@@ -104,7 +105,7 @@ object FakeKeyStore {
 
     // Key and algorithm
     certInfo.set(X509CertInfo.KEY, new CertificateX509Key(keyPair.getPublic))
-    val algorithm = new AlgorithmId(KeystoreSettings.SignatureAlgorithmOID)
+    val algorithm = AlgorithmId.get("SHA256WithRSA")
     certInfo.set(X509CertInfo.ALGORITHM_ID, new CertificateAlgorithmId(algorithm))
 
     // Create a new certificate and sign it

--- a/ssl-config-core/src/test/scala/com/typesafe/sslconfig/ssl/AlgorithmsSpec.scala
+++ b/ssl-config-core/src/test/scala/com/typesafe/sslconfig/ssl/AlgorithmsSpec.scala
@@ -5,10 +5,10 @@
 package com.typesafe.sslconfig.ssl
 
 import org.specs2.mutable._
+import java.security.{ KeyPairGenerator, SecureRandom }
 
-import java.security.{ SecureRandom, KeyPairGenerator }
 import org.joda.time.Instant
-import sun.security.x509.AlgorithmId
+import sun.security.util.ObjectIdentifier
 
 object AlgorithmsSpec extends Specification {
   import Algorithms._
@@ -24,7 +24,7 @@ object AlgorithmsSpec extends Specification {
       val keyGen = KeyPairGenerator.getInstance("RSA")
       keyGen.initialize(1024, new SecureRandom())
       val pair = keyGen.generateKeyPair()
-      val cert = CertificateGenerator.generateCertificate(dn, pair, from.toDate, to.toDate, "SHA1WithRSA", AlgorithmId.sha1WithRSAEncryption_oid)
+      val cert = CertificateGenerator.generateCertificate(dn, pair, from.toDate, to.toDate, "SHA1WithRSA")
 
       // RSA is getModulus.bitLength
       keySize(cert.getPublicKey) must_== Some(1024)
@@ -39,7 +39,7 @@ object AlgorithmsSpec extends Specification {
       val keyGen = KeyPairGenerator.getInstance("DSA")
       keyGen.initialize(1024, new SecureRandom())
       val pair = keyGen.generateKeyPair()
-      val cert = CertificateGenerator.generateCertificate(dn, pair, from.toDate, to.toDate, "SHA1WithDSA", AlgorithmId.sha1WithDSA_oid)
+      val cert = CertificateGenerator.generateCertificate(dn, pair, from.toDate, to.toDate, "SHA1WithDSA")
 
       // DSA is getP.bitLength
       keySize(cert.getPublicKey) must_== Some(1024)


### PR DESCRIPTION
Fixes https://github.com/lightbend/ssl-config/issues/268

Use `AlgorithmId.get("")` instead of using the OID directly, as JDK 15 removes methods and there is not a common interface fir it.