### PR TITLE
Fix the PKCS12 algorithm bug

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,10 @@ lazy val sslConfigCore = project.in(file("ssl-config-core"))
   .settings(
     crossScalaVersions := Seq(Version.scala213, Version.scala212, Version.scala211),
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
+    // work around for https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8266261
+    // also https://bugs.openjdk.java.net/browse/JDK-8266279
+    Test / fork := true,
+    Test / javaOptions += "-Dkeystore.pkcs12.keyProtectionAlgorithm=PBEWithHmacSHA256AndAES_256",
     name := "ssl-config-core",
     mimaReportSignatureProblems := true,
     mimaPreviousArtifacts ++= (((CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION
A recent JDK change has resulted in tests failing with the following exception:

```
java.security.KeyStoreException: Key protection  algorithm not found: java.security.UnrecoverableKeyException: Encrypt Private Key failed: unrecognized algorithm name: PBEWithSHA1AndDESede (PKCS12KeyStore.java:677)
```

This is filed as https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8266261 /
https://bugs.openjdk.java.net/browse/JDK-8266279

and has a workaround in setting the key protection algorithm manually.

"-Dkeystore.pkcs12.keyProtectionAlgorithm=PBEWithHmacSHA256AndAES_256"