### PR TITLE
Bring back a couple of configs and classes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,16 @@ lazy val sslConfigCore = project
     mimaReportSignatureProblems := true,
     mimaPreviousArtifacts       := Set("com.typesafe" %% "ssl-config-core" % "0.7.0"),
     mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters
+        .exclude[IncompatibleResultTypeProblem]("com.typesafe.sslconfig.ssl.SSLConfigSettings.<init>$default$10"),
+      ProblemFilters
+        .exclude[IncompatibleResultTypeProblem]("com.typesafe.sslconfig.ssl.SSLConfigSettings.<init>$default$11"),
+      ProblemFilters
+        .exclude[IncompatibleResultTypeProblem]("com.typesafe.sslconfig.ssl.SSLConfigSettings.<init>$default$9"),
+      ProblemFilters
+        .exclude[IncompatibleResultTypeProblem]("com.typesafe.sslconfig.ssl.SSLConfigSettings.<init>$default$7"),
+      ProblemFilters
+        .exclude[IncompatibleResultTypeProblem]("com.typesafe.sslconfig.ssl.SSLConfigSettings.<init>$default$8"),
     ),
     libraryDependencies ++= Dependencies.sslConfigCore,
     libraryDependencies ++= Dependencies.testDependencies,

--- a/ssl-config-core/src/main/resources/reference.conf
+++ b/ssl-config-core/src/main/resources/reference.conf
@@ -22,6 +22,40 @@ ssl-config {
   # The enabled protocols. If empty, uses the platform default.
   enabledProtocols = ["TLSv1.3", "TLSv1.2"]
 
+  # The hostname verifier class.
+  # If non null, should be the fully qualify classname of a class that implements HostnameVerifier,
+  # otherwise the default will be used.
+  #
+  # BE AWARE:
+  # This config is kept for compatibilby only and is NOT used by:
+  #  - SSL Config itself
+  #  - Play WS
+  # This config is used by the following 3rd party libraries and their versions:
+  #  - Pekko < v2, Pekko HTTP < v2
+  #  - Akka <= v2.8, Akka HTTP <= v10.5
+  #hostnameVerifierClass = null
+
+  #sslParameters {
+  #
+  # BE AWARE:
+  # These configs are kept for compatibilby only and are NOT used by:
+  #  - SSL Config itself
+  #  - Play WS
+  # These config are used by the following 3rd party libraries and their versions:
+  #  - Pekko HTTP < v2
+  #  - Akka HTTP <= v10.5
+  #
+  #  # translates to a setNeedClientAuth / setWantClientAuth calls
+  #  # "default" – leaves the (which for JDK8 means wantClientAuth and needClientAuth are set to false.)
+  #  # "none"    – `setNeedClientAuth(false)`
+  #  # "want"    – `setWantClientAuth(true)`
+  #  # "need"    – `setNeedClientAuth(true)`
+  #  clientAuth = "default"
+  #
+  #  # protocols (names)
+  #  protocols = []
+  #}
+
   # Configuration for the key manager
   keyManager {
     # The key manager algorithm. If empty, uses the platform default.
@@ -81,6 +115,32 @@ ssl-config {
 
     # If non null, overrides the platform default for whether unsafe renegotiation should be allowed.
     allowUnsafeRenegotiation = null
+
+    # Whether hostname verification should be disabled
+    #
+    # BE AWARE:
+    # This config is kept for compatibilby only and is NOT used by:
+    #  - SSL Config itself
+    #  - Play WS
+    # This config is used by the following 3rd party libraries and their versions:
+    #  - Pekko < v2, Pekko HTTP < v2
+    #  - Akka <= v2.8, Akka HTTP <= v10.5
+    #  - Gigahorse (https://github.com/eed3si9n/gigahorse)
+    #disableHostnameVerification = false
+
+    # Whether the SNI (Server Name Indication) TLS extension should be disabled
+    # This setting MAY be respected by client libraries.
+    #
+    # https://tools.ietf.org/html/rfc3546#sectiom-3.1
+    #
+    # BE AWARE:
+    # This config is kept for compatibilby only and is NOT used by:
+    #  - SSL Config itself
+    #  - Play WS
+    # This config is used by the following 3rd party libraries and their versions:
+    #  - Pekko < v2, Pekko HTTP < v2
+    #  - Akka <= v2.8, Akka HTTP <= v10.5
+    #disableSNI = false
 
     # Whether any certificate should be accepted or not
     acceptAnyCertificate = false

--- a/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/Config.scala
+++ b/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/Config.scala
@@ -260,7 +260,8 @@ object SSLDebugConfig {
  *                                 default.
  * @param disableHostnameVerification Whether hostname verification should be disabled. Be aware: SSL Config itself is not using this config.
  *                                    However, it was kept because 3rd party libraries rely on its existence.
- * @param disableSNI Whether SNI should be disabled (up to client library to respect this setting or not)
+ * @param disableSNI Whether SNI should be disabled (up to client library to respect this setting or not). Be aware: SSL Config itself is not using this config.
+ *                   However, it was kept because 3rd party libraries rely on its existence.
  * @param acceptAnyCertificate Whether any X.509 certificate should be accepted or not.
  */
 final class SSLLooseConfig private[sslconfig] (
@@ -338,9 +339,12 @@ object SSLParametersConfig {
  * @param revocationLists The revocation lists to check.
  * @param enabledCipherSuites If defined, override the platform default cipher suites.
  * @param enabledProtocols If defined, override the platform default protocols.
+ * @param sslParametersConfig Be aware: SSL Config itself is not using this config.
+ *                            However, it was kept because 3rd party libraries rely on its existence.
  * @param keyManagerConfig The key manager configuration.
  * @param trustManagerConfig The trust manager configuration.
- * @param hostnameVerifierClass The hostname verifier class.
+ * @param hostnameVerifierClass The hostname verifier class. Be aware: SSL Config itself is not using this config.
+ *                              However, it was kept because 3rd party libraries rely on its existence.
  * @param secureRandom The SecureRandom instance to use. Let the platform choose if None.
  * @param debug The debug config.
  * @param loose Loose configuratino parameters

--- a/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/Config.scala
+++ b/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/Config.scala
@@ -260,6 +260,7 @@ object SSLDebugConfig {
  *                                 default.
  * @param disableHostnameVerification Whether hostname verification should be disabled. Be aware: SSL Config itself is not using this config.
  *                                    However, it was kept because 3rd party libraries rely on its existence.
+ * @param disableSNI Whether SNI should be disabled (up to client library to respect this setting or not)
  * @param acceptAnyCertificate Whether any X.509 certificate should be accepted or not.
  */
 final class SSLLooseConfig private[sslconfig] (
@@ -267,27 +268,31 @@ final class SSLLooseConfig private[sslconfig] (
     val allowLegacyHelloMessages: Option[Boolean] = None,
     val allowUnsafeRenegotiation: Option[Boolean] = None,
     val disableHostnameVerification: Boolean = false,
+    val disableSNI: Boolean = false,
 ) {
 
   def withAcceptAnyCertificate(value: Boolean): SSLLooseConfig             = copy(acceptAnyCertificate = value)
   def withAllowLegacyHelloMessages(value: Option[Boolean]): SSLLooseConfig = copy(allowLegacyHelloMessages = value)
   def withAllowUnsafeRenegotiation(value: Option[Boolean]): SSLLooseConfig = copy(allowUnsafeRenegotiation = value)
   def withDisableHostnameVerification(value: Boolean): SSLLooseConfig      = copy(disableHostnameVerification = value)
+  def withDisableSNI(value: Boolean): SSLLooseConfig                       = copy(disableSNI = value)
 
   private def copy(
       acceptAnyCertificate: Boolean = acceptAnyCertificate,
       allowLegacyHelloMessages: Option[Boolean] = allowLegacyHelloMessages,
       allowUnsafeRenegotiation: Option[Boolean] = allowUnsafeRenegotiation,
       disableHostnameVerification: Boolean = disableHostnameVerification,
+      disableSNI: Boolean = disableSNI,
   ): SSLLooseConfig = new SSLLooseConfig(
     acceptAnyCertificate = acceptAnyCertificate,
     allowLegacyHelloMessages = allowLegacyHelloMessages,
     allowUnsafeRenegotiation = allowUnsafeRenegotiation,
     disableHostnameVerification = disableHostnameVerification,
+    disableSNI = disableSNI,
   )
 
   override def toString =
-    s"""SSLLooseConfig(${acceptAnyCertificate},${allowLegacyHelloMessages},${allowUnsafeRenegotiation},${disableHostnameVerification})"""
+    s"""SSLLooseConfig(${acceptAnyCertificate},${allowLegacyHelloMessages},${allowUnsafeRenegotiation},${disableHostnameVerification},${disableSNI})"""
 }
 object SSLLooseConfig {
   def apply() = new SSLLooseConfig()
@@ -459,12 +464,14 @@ class SSLConfigParser(c: EnrichedConfig, classLoader: ClassLoader, loggerFactory
     val allowMessages               = config.getOptional[Boolean]("allowLegacyHelloMessages")
     val allowUnsafeRenegotiation    = config.getOptional[Boolean]("allowUnsafeRenegotiation")
     val disableHostnameVerification = config.getOptional[Boolean]("disableHostnameVerification").getOrElse(false)
+    val disableSNI                  = config.get[Boolean]("disableSNI")
     val acceptAnyCertificate        = config.get[Boolean]("acceptAnyCertificate")
 
     new SSLLooseConfig(
       allowLegacyHelloMessages = allowMessages,
       allowUnsafeRenegotiation = allowUnsafeRenegotiation,
       disableHostnameVerification = disableHostnameVerification,
+      disableSNI = disableSNI,
       acceptAnyCertificate = acceptAnyCertificate
     )
   }

--- a/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/DefaultHostnameVerifier.scala
+++ b/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/DefaultHostnameVerifier.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015 - 2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.typesafe.sslconfig.ssl
+
+import java.security.cert.Certificate
+import java.security.Principal
+import javax.net.ssl.HostnameVerifier
+import javax.net.ssl.SSLSession
+
+import com.typesafe.sslconfig.util.LoggerFactory
+import sun.security.util.HostnameChecker
+
+@deprecated(
+  "DefaultHostnameVerifier has been deprecated and does nothing.  Please use the javax.net.debug system property.",
+  "0.4.0"
+)
+class DefaultHostnameVerifier(mkLogger: LoggerFactory) extends HostnameVerifier {
+  private val logger = mkLogger(getClass)
+
+  def hostnameChecker: HostnameChecker = {
+    logger.warn(
+      "DefaultHostnameVerifier has been deprecated and does nothing.  Please use the javax.net.debug system property."
+    )
+    HostnameChecker.getInstance(HostnameChecker.TYPE_TLS)
+  }
+
+  def matchKerberos(hostname: String, principal: Principal) = {
+    logger.warn(
+      "DefaultHostnameVerifier has been deprecated and does nothing.  Please use the javax.net.debug system property."
+    )
+    true
+  }
+
+  def isKerberos(principal: Principal): Boolean = {
+    logger.warn(
+      "DefaultHostnameVerifier has been deprecated and does nothing.  Please use the javax.net.debug system property."
+    )
+    true
+  }
+
+  def verify(hostname: String, session: SSLSession): Boolean = {
+    logger.warn(
+      "DefaultHostnameVerifier has been deprecated and does nothing.  Please use the javax.net.debug system property."
+    )
+    true
+  }
+
+  /** INTERNAL API */
+  def matchCertificates(hostname: String, peerCertificates: Array[Certificate]): Boolean = {
+    logger.warn(
+      "DefaultHostnameVerifier has been deprecated and does nothing.  Please use the javax.net.debug system property."
+    )
+    true
+  }
+}

--- a/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/DisabledComplainingHostnameVerifier.scala
+++ b/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/DisabledComplainingHostnameVerifier.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2015 - 2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.typesafe.sslconfig.ssl
+
+import javax.net.ssl.HostnameVerifier
+import javax.net.ssl.SSLSession
+
+import com.typesafe.sslconfig.util.LoggerFactory
+
+/**
+ * Add a disabled but complaining hostname verifier.
+ */
+class DisabledComplainingHostnameVerifier(mkLogger: LoggerFactory) extends HostnameVerifier {
+
+  private val logger = mkLogger(getClass)
+
+  private val defaultHostnameVerifier = new NoopHostnameVerifier
+
+  override def verify(hostname: String, sslSession: SSLSession): Boolean = {
+    val hostNameMatches = defaultHostnameVerifier.verify(hostname, sslSession)
+    if (!hostNameMatches) {
+      // TODO fix config paths
+      val msg =
+        s"Hostname verification failed on hostname $hostname, " +
+          "but the connection was accepted because ssl-config.loose.disableHostnameVerification is enabled. " +
+          "Please fix the X.509 certificate on the host to remove this warning."
+      logger.warn(msg)
+    }
+    true
+  }
+}

--- a/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/NoopHostnameVerifier.scala
+++ b/ssl-config-core/src/main/scala/com/typesafe/sslconfig/ssl/NoopHostnameVerifier.scala
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) 2015 - 2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.typesafe.sslconfig.ssl
+
+import javax.net.ssl.HostnameVerifier
+import javax.net.ssl.SSLSession
+
+final class NoopHostnameVerifier extends HostnameVerifier {
+  def verify(hostname: String, sslSession: SSLSession): Boolean = true
+}


### PR DESCRIPTION
So I cleaned up ssl-config, turns out that Akka <= v2.8 (and therefore also Pekko < v2) does use some configs and classes that are not even used by ssl-config itself, which was the reason I removed them. However when upgrading to ssl-config v0.7.0 apps that rely on Pekko < v2 and Akka <= v2.8 would break... 
So I brought those required classes and configs  back. So next v0.7.1 release should  finally be a drop in replacement for Akka and Pekko.
Tested locally with akka, akka-http, pekko, pekko-http, gigahorse etc.
I hope that is it for now.